### PR TITLE
Replaced references to 'Amazon S3 bucket' with 'S3 bucket'.

### DIFF
--- a/docs/deployment_guide/partner_editable/pre_deployment.adoc
+++ b/docs/deployment_guide/partner_editable/pre_deployment.adoc
@@ -2,9 +2,9 @@
 
 == Predeployment steps
 
-=== Create an Amazon S3 bucket
+=== Create an Amazon Simple Storage Service (Amazon S3) bucket
 
-You need to create an Amazon S3 bucket in one of the AWS Regions. See AWS documentation on how to https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html[Create your first S3 bucket^].
+You need to create an S3 bucket in one of the AWS Regions. See AWS documentation on how to https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html[Create your first S3 bucket^].
 
 To upload files into your S3 bucket, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/uploading-an-object-bucket.html[Upload an object to your bucket^].
 

--- a/docs/deployment_guide/partner_editable/troubleshooting.adoc
+++ b/docs/deployment_guide/partner_editable/troubleshooting.adoc
@@ -1,5 +1,5 @@
 // Add any unique troubleshooting steps here.
-Make notes of the the log files that are generated in output s3 bucket: 
+Make notes of the the log files that are generated in the output S3 bucket: 
 
 * bootstrap.log - STDOUT of the high overview of the events during deployment of Red Hat OpenShift Container Platform and IBM Cloud Pak for Security.  
 * ocp_install.log - STDOUT of the deployment of Red Hat OpenShift Container Platform using IPI.


### PR DESCRIPTION
*Description of changes:*

- Replaced references to 'Amazon S3 bucket' with 'S3 bucket'.
- Replaced 'Amazon S3 bucket with 'Amazon Simple Storage Service (Amazon S3)' in section sub-heading.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
